### PR TITLE
Fix a valgrind warning when resolving hostnames

### DIFF
--- a/include/net_io.h
+++ b/include/net_io.h
@@ -80,7 +80,6 @@ typedef union ci_inaddr {
                      ci_in6_addr_u32(addr)[3] = htonl(0xFFFFFFFF))
 
 #define CI_IPLEN      46
-#define CI_SOCKADDR_SIZE sizeof(struct sockaddr_storage)
 
 #else /*IPV4 only*/
 
@@ -91,7 +90,6 @@ typedef struct in_addr ci_in_addr_t;
 
 
 #define CI_IPLEN      16
-#define CI_SOCKADDR_SIZE sizeof(struct sockaddr_in)
 #endif
 
 #define wait_for_read       0x1

--- a/modules/dnsbl_tables.c
+++ b/modules/dnsbl_tables.c
@@ -206,7 +206,12 @@ static ci_vector_t  *resolv_hostname(char *hostname)
 
     if (vect) {
         for (cur = res; cur != NULL; cur = cur->ai_next) {
-            memcpy(&(addr.sockaddr), cur->ai_addr, CI_SOCKADDR_SIZE);
+#ifndef USE_IPV6
+            if (res->ai_family != AF_INET) {
+                continue;
+            }
+#endif
+            memcpy(&(addr.sockaddr), cur->ai_addr, cur->ai_addrlen);
             ci_fill_sockaddr(&addr);
             if (ci_sockaddr_t_to_ip(&addr, buf, sizeof(buf)))
                 (void)ci_str_vector_add(vect, buf);

--- a/net_io.c
+++ b/net_io.c
@@ -221,8 +221,15 @@ int ci_host_to_sockaddr_t(const char *servername, ci_sockaddr_t * addr, int prot
         ci_debug_printf(5, "Error getting addrinfo for '%s':%s\n", servername, gai_strerror(ret));
         return 0;
     }
+#ifndef USE_IPV6
+    if (res->ai_family != AF_INET) {
+        ci_debug_printf(5, "Did not get an IPv4 address for '%s' (built without IPv6 support)\n", servername);
+        freeaddrinfo(res);
+        return 0;
+    }
+#endif
     //fill the addr..... and
-    memcpy(&(addr->sockaddr), res->ai_addr, CI_SOCKADDR_SIZE);
+    memcpy(&(addr->sockaddr), res->ai_addr, res->ai_addrlen);
     freeaddrinfo(res);
     ci_fill_sockaddr(addr);
     return 1;


### PR DESCRIPTION
- Don't copy more bytes than available when resolving hostnames.
  The old code copied too many bytes when c-icap has been built with IPv6 support and c-icap got an IPv4 address.
  Fixed valgrind warning: "Invalid read of size 16"
- Log an error when c-icap gets an IPv6 address but has been built without IPv6 support