### PR TITLE
* Fix valgrind warning by initializing memory properly.

### DIFF
--- a/filetype.c
+++ b/filetype.c
@@ -385,10 +385,11 @@ int ci_magics_db_file_add(struct ci_magics_db *db, const char *filename)
         return 0;
     }
 
+    memset(&record, 0, sizeof(struct ci_magic_record));
     lineNum = 0;
     error = 0;
     while (!error && fgets(line, RECORD_LINE, f) != NULL) {
-        lineNum ++;
+        lineNum++;
         ci_str_trim(line);
         ret = parse_record(line, &record);
         if (!ret)
@@ -477,7 +478,7 @@ static int check_magics(const struct ci_magics_db *db, const char *buf, int bufl
     int i, j;
     int matched;
     const char *test;
-    int required;;
+    int required;
     for (i = 0; i < db->magics_num; i++) {
         matched = 0;
         for (j = 0; j < db->magics[i]->blocks_num; ++j) {

--- a/util.c
+++ b/util.c
@@ -187,5 +187,6 @@ ci_dyn_array_t *ci_parse_key_value_list(const char *str, char sep)
         }
         k = (e && *e) ? e : NULL;
     }
+    free(s);
     return args_array;
 }


### PR DESCRIPTION
This is somewhat stylistic. However, the memset is necessary as all functions later require valid information. The reset done later is needed between iterations. This partially fixes things like:
==1858622== Use of uninitialised value of size 8
==1858622==    at 0x488FA05: ci_str_trim (util.c:129)
==1858622==    by 0x487FE31: ci_magics_db_file_add (filetype.c:393)
==1858622==    by 0x488107B: ci_magic_db_load (filetype.c:777)
==1858622==    by 0x115B9E: cfg_load_magicfile (cfg_param.c:562)
==1858622==    by 0x1175EA: process_line (cfg_param.c:922)
==1858622==    by 0x117807: parse_file (cfg_param.c:958)
==1858622==    by 0x117A7B: config (cfg_param.c:1020)
==1858622==    by 0x110C75: main (aserver.c:154)
==1858622==  Uninitialised value was created by a stack allocation
==1858622==    at 0x487FD76: ci_magics_db_file_add (filetype.c:375)

It does not completely fix it and I have yet to find a complete solution. This also fixes a memory leak I believe.