### PR TITLE
Hooks for process and worker thread lifetime events

### DIFF
--- a/include/service.h
+++ b/include/service.h
@@ -204,6 +204,31 @@ struct  ci_service_module {
     void (*mod_close_service)();
 
     /**
+       \brief Pointer to the function which called after the c-icap child
+     * process is initialized, but before it spawns worker threads.
+     */
+    void (*mod_init_server_process)();
+
+    /**
+       \brief Pointer to the function which called on c-icap child
+     * process shutdown.
+     */
+    void (*mod_close_server_process)();
+
+    /**
+       \brief Pointer to the function which called after the c-icap child
+     * process has spawn a thread, but before the threads starts to serve
+     * requests.
+     */
+    void (*mod_init_server_thread)();
+
+    /**
+       \brief Pointer to the function which called on c-icap child
+     * process thread shutdown.
+     */
+    void (*mod_close_server_thread)();
+
+    /**
      \brief Pointer to the function called when a new request for this services
      * arrives to c-icap server.
      *

--- a/info.c
+++ b/info.c
@@ -46,6 +46,10 @@ CI_DECLARE_MOD_DATA ci_service_module_t info_service = {
     NULL,                           /* post_init_service. Service initialization after c-icap
                     configured. Not used here */
     info_close_service,           /* mod_close_service. Called when service shutdowns. */
+    NULL,                           /* mod_init_server_process */
+    NULL,                           /* mod_close_server_process */
+    NULL,                           /* mod_init_server_thread */
+    NULL,                           /* mod_close_server_thread */
     info_init_request_data,         /* mod_init_request_data */
     info_release_request_data,      /* mod_release_request_data */
     info_check_preview_handler,     /* mod_check_preview_handler */

--- a/modules/perl_handler.c
+++ b/modules/perl_handler.c
@@ -91,6 +91,10 @@ ci_service_module_t *load_perl_module(char *service_file)
     service->mod_init_service = perl_init_service;
     service->mod_post_init_service = NULL;
     service->mod_close_service = perl_close_service;
+    service->mod_init_server_process = NULL;
+    service->mod_close_server_process = NULL;
+    service->mod_init_server_thread = NULL;
+    service->mod_close_server_thread = NULL;
     service->mod_init_request_data = perl_init_request_data;
     service->mod_release_request_data = perl_release_request_data;
     service->mod_check_preview_handler = perl_check_preview_handler;

--- a/service.c
+++ b/service.c
@@ -474,6 +474,50 @@ int post_init_services()
     return 1;
 }
 
+void init_services_in_server_process()
+{
+    int i;
+    ci_service_xdata_t *xdata;
+    for (i = 0; i < services_num; i++) {
+        if (service_list[i]->mod_init_server_process != NULL) {
+            service_list[i]->mod_init_server_process();
+        }
+    }
+}
+
+void close_services_in_server_process()
+{
+    int i;
+    ci_service_xdata_t *xdata;
+    for (i = 0; i < services_num; i++) {
+        if (service_list[i]->mod_close_server_process != NULL) {
+            service_list[i]->mod_close_server_process();
+        }
+    }
+}
+
+void init_services_in_server_thread()
+{
+    int i;
+    ci_service_xdata_t *xdata;
+    for (i = 0; i < services_num; i++) {
+        if (service_list[i]->mod_init_server_thread != NULL) {
+            service_list[i]->mod_init_server_thread();
+        }
+    }
+}
+
+void close_services_in_server_thread()
+{
+    int i;
+    ci_service_xdata_t *xdata;
+    for (i = 0; i < services_num; i++) {
+        if (service_list[i]->mod_close_server_thread != NULL) {
+            service_list[i]->mod_close_server_thread();
+        }
+    }
+}
+
 int release_services()
 {
     int i;

--- a/services/echo/srv_echo.c
+++ b/services/echo/srv_echo.c
@@ -45,6 +45,10 @@ CI_DECLARE_MOD_DATA ci_service_module_t service = {
     NULL,                           /* post_init_service. Service initialization after c-icap
                     configured. Not used here */
     echo_close_service,           /* mod_close_service. Called when service shutdowns. */
+    NULL,                           /* mod_init_server_process */
+    NULL,                           /* mod_close_server_process */
+    NULL,                           /* mod_init_server_thread */
+    NULL,                           /* mod_close_server_thread */
     echo_init_request_data,         /* mod_init_request_data */
     echo_release_request_data,      /* mod_release_request_data */
     echo_check_preview_handler,     /* mod_check_preview_handler */

--- a/services/ex-206/srv_ex206.c
+++ b/services/ex-206/srv_ex206.c
@@ -45,6 +45,10 @@ CI_DECLARE_MOD_DATA ci_service_module_t service = {
     NULL,                           /* post_init_service. Service initialization after c-icap
                     configured. Not used here */
     ex206_close_service,           /* mod_close_service. Called when service shutdowns. */
+    NULL,                            /* mod_init_server_process */
+    NULL,                            /* mod_close_server_process */
+    NULL,                            /* mod_init_server_thread */
+    NULL,                            /* mod_close_server_thread */
     ex206_init_request_data,         /* mod_init_request_data */
     ex206_release_request_data,      /* mod_release_request_data */
     ex206_check_preview_handler,     /* mod_check_preview_handler */


### PR DESCRIPTION
Add hooks to allow users to perform operations upon process or thread
initialization or destruction.