### PR TITLE
Fix requests processing loop to honor KeepAliveTimeout

### DIFF
--- a/mpmt_server.c
+++ b/mpmt_server.c
@@ -661,7 +661,13 @@ int thread_main(server_decl_t * srv)
 
             ci_debug_printf(8, "Keep-alive:%d\n",
                             srv->current_req->keepalive);
-            if (srv->current_req->keepalive && keepalive_request(srv->current_req)) {
+            if (srv->current_req->keepalive) {
+                if (keepalive_request(srv->current_req) <= 0) {
+                    /* timeout or error. done with this conn */
+                    ci_debug_printf(5, "keepalive request timed-out, or connection closed/errored...\n");
+                    request_status = CI_NO_STATUS;
+                    break;
+                }
                 ci_debug_printf(8,
                                 "Server %d going to serve new request from client (keep-alive) \n",
                                 srv->srv_id);


### PR DESCRIPTION
Admin is allowed to configure a KeepAliveTimeout:
  The maximum time in seconds waiting for a new requests before a
  connection will be closed.
  If the value is set to -1, there is no timeout.

The processing loop calls keepalive_request() to implement the wait; 'keepalive_request' can return either due to a inactivity timeout, or upon connection close/error, or due to a new request pending.

Alas, the return code isn't checked, and the code always continues to beginning of loop, invoking a new 'process_request()' call.

The problem is that in a *genuine* timeout event (no further exchanges from the icap client on the connection), continuing to process_request will cause an *additional* blocking wait:
  process_request()
    do_request()
      parse_header()
        ci_read_icap_header(req, h, TIMEOUT)  # defaults to 300s
          wait_for_data(req->connection, timeout, ci_wait_for_read)

which means the KeepAliveTimeout value isn't really honored, and the worker thread will stall for an additional timeout (either until new request arrives or until client closed the connection, or timeout).

Fix, by testing keepalive_request() return code: if it is not positive (i.e. timeout or error), just break out of the requests processing loop, which will close the connection.