### PR TITLE
configure.ac: Include <stdlib.h> for exit() in the semaphore probe

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -986,6 +986,7 @@ AC_CACHE_CHECK([if posix 1003.1b interprocess semaphores works], ac_cv_10031b_ip
    [AC_LANG_SOURCE([
    #include <semaphore.h>
    #include <sys/wait.h>
+   #include <stdlib.h>
 
    int main(int argc,char **argv){
          sem_t s;


### PR DESCRIPTION
Otherwise, the probe will fail unconditionally (not test anything) if the C compiler does not support implicit function declarations.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
