### PR TITLE
configure.ac: link with -lm

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -60,7 +60,7 @@ case "$host_os" in
 	CFLAGS="-D_REENTRANT $CFLAGS"
 	THREADS_LDADD="-lpthread"
 	THREADS_LDFLAGS=""
-	LIBS_LDFLAGS=""
+	LIBS_LDFLAGS="-lm"
      ;;
      solaris2.*)
      	  CFLAGS="-D_REENTRANT -D_POSIX_PTHREAD_SEMANTICS $CFLAGS"


### PR DESCRIPTION
Link with `-lm` to avoid the following build failure since version 0.6.0 and https://github.com/c-icap/c-icap-server/commit/bc9f45400091b862df4bd398888c8c360c8bf9be:

```
/home/fabrice/buildroot/output/host/opt/ext-toolchain/bin/../lib/gcc/x86_64-buildroot-linux-gnu/13.2.0/../../../../x86_64-buildroot-linux-gnu/bin/ld: ./.libs/libicapapi.so: undefined reference to `exp'
```