### PR TITLE
Fix two memory leaks related to ci_client_library

### DIFF
--- a/client.c
+++ b/client.c
@@ -977,5 +977,6 @@ void ci_client_library_release()
         free(CI_USER_AGENT);
         CI_USER_AGENT = NULL;
     }
+    ci_cfg_lib_destroy();
     ci_buffers_destroy();
 }

--- a/mem.c
+++ b/mem.c
@@ -1006,6 +1006,7 @@ static void pool_allocator_destroy(ci_mem_allocator_t *allocator)
     ci_thread_mutex_destroy(&palloc->mutex);
     free(palloc->name);
     free(palloc);
+    free(allocator->name);
 }
 
 ci_mem_allocator_t *ci_create_pool_allocator(const char *name, int items_size)


### PR DESCRIPTION
While switching to 0.6 I came across two memory leaks when using ci_client_library_init()/_release().

The strdup call in mem.c:1026 is never cleaned up.

ci_client_library_init calls ci_cfg_lib_init, but ci_client_library_release doesn't call ci_cfg_lib_destroy. As a result the cfg_params_allocator is never destroyed.