### PR TITLE
Fix a Y2038 bug by replacing `Int32x32To64` with regular multiplication

### DIFF
--- a/os/win32/utilfunc.c
+++ b/os/win32/utilfunc.c
@@ -99,7 +99,7 @@ void ci_strntime(char *buf, size_t size)
 void ci_to_strntime(char *buf, size_t size, const time_t *tm)
 {
     assert(size > 0);
-    LONGLONG ll = Int32x32To64(*tm, 10000000) + 116444736000000000;
+    LONGLONG ll = (*tm * 10000000LL) + 116444736000000000LL;
     FILETIME ft;
     ft.dwLowDateTime = (DWORD) ll;
     ft.dwHighDateTime = ll >>32;
@@ -124,7 +124,7 @@ void ci_strntime_rfc822(char *buf, size_t size)
 void ci_to_strntime_rfc822(char *buf, size_t size, const time_t *tm)
 {
     assert(size > 0);
-    LONGLONG ll = Int32x32To64(*tm, 10000000) + 116444736000000000;
+    LONGLONG ll = (*tm * 10000000LL) + 116444736000000000LL;
     FILETIME ft;
     ft.dwLowDateTime = (DWORD) ll;
     ft.dwHighDateTime = ll >>32;


### PR DESCRIPTION
`Int32x32To64` macro internally truncates the arguments to int32, while `time_t` is 64-bit on most/all modern platforms. Therefore, usage of this macro creates a Year 2038 bug.

I detailed this issue a while ago in a writeup, and spotted the same issue in this repository when updating the list of affected repositories:
<https://cookieplmonster.github.io/2022/02/17/year-2038-problem/>