### PR TITLE
Patch for GCC15 issues - BZ2339953

### DIFF
--- a/include/module.h
+++ b/include/module.h
@@ -96,7 +96,7 @@ typedef struct http_auth_method {
     void *(*create_auth_data)(const char *authorization_header,const char **username);
     void (*release_auth_data)(void *data);
     char *(*authentication_header)(ci_request_t *req);
-    void (*release_authentication_header)();
+    void (*release_authentication_header)(const char *auth_header);
     struct ci_conf_entry *conf_table;
 } http_auth_method_t;
 

--- a/mpmt_server.c
+++ b/mpmt_server.c
@@ -138,7 +138,7 @@ static void sigchld_handler_main(int sig)
     /*Do nothing the signal will be ignored..... */
 }
 
-static void sighup_handler_main()
+static void sighup_handler_main(int sig)
 {
     c_icap_reconfigure = 1;
 }


### PR DESCRIPTION
The mass rebuild for Fedora 42, with the recently released GCC 15 compiler generated build errors, this is a patch to fix them.

The issues were all Function declarations without parameters (see [https://gcc.gnu.org/gcc-15/porting_to.html](https://gcc.gnu.org/gcc-15/porting_to.html)) and kind of trivial fixes.