### PR TITLE
Fix off-by-one errors causing out-of-bounds reads and writes

### DIFF
--- a/filetype.c
+++ b/filetype.c
@@ -256,7 +256,7 @@ static int parse_record(char *line, struct ci_magic_record *record)
                 num[3] = '\0';
                 c = strtol(num, NULL, 8);
             }
-            if (c > 256 || c < 0) {
+            if (c > 255 || c < 0) {
                 return -1;
             }
             record->blocks[record->blocks_num].magic[i++] = c;
@@ -632,7 +632,7 @@ static int check_unicode(unsigned char *buf, int buflen)
         return -1;
 
     /*The only check we can do is for the ascii characters ...... */
-    for (i = 2; i < buflen; i += 2) {
+    for (i = 2; i + 1 < buflen; i += 2) {
         if (endian) {
             if (buf[i] == 0 && buf[i + 1] < 128
                     && text_chars[buf[i + 1]] != T)

--- a/header.c
+++ b/header.c
@@ -355,7 +355,7 @@ static const char *do_header_search(const ci_headers_list_t * h, const char *hea
         if (strncasecmp(check_head, header, header_size) == 0) {
             lval = check_head + header_size + 1;
             if (value) {
-                while (lval <= h_end && (*lval == ' ' || *lval == '\t'))
+                while (lval < h_end && (*lval == ' ' || *lval == '\t'))
                     ++(lval);
                 *value = lval;
             }

--- a/include/stats.h
+++ b/include/stats.h
@@ -541,7 +541,7 @@ static inline ci_kbs_t ci_stat_memblock_get_kbs(const ci_stat_memblock_t *block,
 static inline void ci_stat_membock_uint64_inc(ci_stat_memblock_t *mem_block, int ID, uint64_t count)
 {
     _CI_ASSERT(mem_block);
-    if (ID < 0 || ID > mem_block->stats_count)
+    if (ID < 0 || ID >= mem_block->stats_count)
         return;
     STAT_INT64_INC(mem_block, ID, count);
 }
@@ -549,7 +549,7 @@ static inline void ci_stat_membock_uint64_inc(ci_stat_memblock_t *mem_block, int
 static inline void ci_stat_membock_uint64_dec(ci_stat_memblock_t *mem_block, int ID, uint64_t count)
 {
     _CI_ASSERT(mem_block);
-    if (ID < 0 || ID > mem_block->stats_count)
+    if (ID < 0 || ID >= mem_block->stats_count)
         return;
     STAT_INT64_DEC(mem_block, ID, count);
 }
@@ -557,7 +557,7 @@ static inline void ci_stat_membock_uint64_dec(ci_stat_memblock_t *mem_block, int
 static inline void ci_stat_memblock_kbs_inc(ci_stat_memblock_t *mem_block, int ID, uint64_t count)
 {
     _CI_ASSERT(mem_block);
-    if (ID < 0 || ID > mem_block->stats_count)
+    if (ID < 0 || ID >= mem_block->stats_count)
         return;
     STAT_INT64_INC(mem_block, ID, count);
 }

--- a/info.c
+++ b/info.c
@@ -1369,7 +1369,7 @@ int stats_web_service(ci_request_t *req)
     struct info_req_data *info_data = (struct info_req_data *)info_init_request_data(req);
     info_data->supports_svg = 1;
     int url_size = sizeof(req->service) + sizeof(req->args) + 1;
-    info_data->url = ci_buffer_alloc(sizeof(req->service) + sizeof(req->args));
+    info_data->url = ci_buffer_alloc(url_size);
     snprintf(info_data->url, url_size, "%s%s%s", req->service, (req->args[0] != '\0' ? "?" : ""), req->args);
     if (req->args[0] != '\0') {
         parse_info_arguments(info_data, req->args);

--- a/module.c
+++ b/module.c
@@ -467,7 +467,7 @@ void release_auth_hash(struct auth_hash *hash)
 authenticator_module_t **get_authenticators_list(struct auth_hash *hash,
         int method_id)
 {
-    if (method_id > hash->hash_size)
+    if (method_id >= hash->hash_size)
         return NULL;
     return hash->hash[method_id];
 }
@@ -475,14 +475,14 @@ authenticator_module_t **get_authenticators_list(struct auth_hash *hash,
 int check_to_add_method_id(struct auth_hash *hash, int method_id)
 {
     authenticator_module_t ***new_mem;
-    if (method_id > MAX_HASH_SIZE || method_id < 0) {
+    if (method_id >= MAX_HASH_SIZE || method_id < 0) {
         ci_debug_printf(1,
                         "Method id is %d. Possible bug, please report it to developers!!!!!!\n",
                         method_id);
         return 0;
     }
 
-    while (hash->hash_size < method_id) {
+    while (hash->hash_size <= method_id) {
         new_mem = realloc(hash->hash, hash->hash_size + STEP);
         if (!new_mem) {
             ci_debug_printf(1,

--- a/request_common.c
+++ b/request_common.c
@@ -457,7 +457,7 @@ char *ci_request_set_log_str(ci_request_t *req, char *logstr)
     if (!req->log_str)
         return NULL;
     strncpy(req->log_str, logstr, size);
-    req->log_str[size] = '\0';
+    req->log_str[size - 1] = '\0';
     return req->log_str;
 }
 

--- a/service.c
+++ b/service.c
@@ -609,7 +609,7 @@ service_alias_t *add_service_alias(const char *service_alias, const char *servic
                                (salias && strlen(salias->args)) ? "&" : "",
                                args
         );
-    if (required > MAX_SERVICE_ARGS) {
+    if (required >= MAX_SERVICE_ARGS) {
         ci_debug_printf(1, "Warning: service %s args are truncated", service_aliases[alias_indx].alias);
     }
 

--- a/stats.c
+++ b/stats.c
@@ -280,7 +280,7 @@ void ci_stat_uint64_inc(int ID, uint64_t count)
     if (!STATS || !STATS->mem_block)
         return;
 
-    if (ID < 0 || ID > STATS->mem_block->stats_count)
+    if (ID < 0 || ID >= STATS->mem_block->stats_count)
         return;
 
     ci_atomic_add_u64(&(STATS->mem_block->stats[ID].counter), (uint64_t)count);
@@ -291,7 +291,7 @@ void ci_stat_uint64_dec(int ID, uint64_t count)
     if (!STATS || !STATS->mem_block)
         return;
 
-    if (ID < 0 || ID > STATS->mem_block->stats_count)
+    if (ID < 0 || ID >= STATS->mem_block->stats_count)
         return;
 
     ci_atomic_sub_u64(&(STATS->mem_block->stats[ID].counter), (uint64_t)count);
@@ -302,7 +302,7 @@ void ci_stat_kbs_inc(int ID, uint64_t count)
     if (!STATS || !STATS->mem_block)
         return;
 
-    if (ID < 0 || ID > STATS->mem_block->stats_count)
+    if (ID < 0 || ID >= STATS->mem_block->stats_count)
         return;
 
     ci_kbs_lock_and_update(&(STATS->mem_block->stats[ID].kbs), count);
@@ -313,7 +313,7 @@ void ci_stat_value_set(int ID, uint64_t value)
     if (!STATS || !STATS->mem_block)
         return;
 
-    if (ID < 0 || ID > STATS->mem_block->stats_count)
+    if (ID < 0 || ID >= STATS->mem_block->stats_count)
         return;
 
     /*This is also can set kbs statistic type*/
@@ -327,7 +327,7 @@ void ci_stat_update(const ci_stat_item_t *stats, int num)
         return;
     for (i = 0; i < num; ++i) {
         int id = stats[i].Id;
-        if ( id < 0 || id > STATS->mem_block->stats_count)
+        if ( id < 0 || id >= STATS->mem_block->stats_count)
             continue; /*May print a warning?*/
         switch (stats[i].type) {
         case CI_STAT_INT64_T:


### PR DESCRIPTION
I found a few off-by-one errors that might cause undefined behaviour, even though not always directly reproducible as it depends on input size and buffer layout, fixing them would help prevent latent issues at any point in time.